### PR TITLE
Change to make "cljr swank" default to safer localhost 

### DIFF
--- a/src/main/resources/cljr/main.clj
+++ b/src/main/resources/cljr/main.clj
@@ -23,7 +23,7 @@
        \newline
        "*  swingrepl: Starts a Clojure swingrepl." \newline
        \newline
-       "*  swank [port]: Start a local swank server on port 4005 (or as specified)." \newline
+       "*  swank [port [host]]: Start a local swank server on localhost port 4005 (or as specified)." \newline
        \newline
        "*  run filename: Runs the given Clojure file." \newline
        \newline

--- a/src/main/resources/cljr/swank.clj
+++ b/src/main/resources/cljr/swank.clj
@@ -3,11 +3,21 @@
 
 (defn swank
   ([]
-     (swank 4005))
+     (swank nil nil))
   ([port]
-     (cond
-      (nil? port) (start-repl 4005)
-      (integer? port) (start-repl port)
-      (string? port) (start-repl (Integer/parseInt port 10))
-      :else (println "Invalid port number: " port))))
+     (swank port nil))
+  ([port host]
+     (let [the-host (cond
+                     (nil? host) "localhost"
+                     (string? host) host
+                     :else (do (println "Invalid hostname:" host)
+                               nil))
+           the-port (cond
+                     (nil? port) 4005
+                     (integer? port) port
+                     (string? port) (try (Integer/parseInt port 10)
+                                         (catch NumberFormatException ex
+                                           nil)))]
+       (when (and the-host the-port)
+         (start-repl the-port :host the-host)))))
 


### PR DESCRIPTION
Please consider the simple change in my repo.

I never noticed this but http://www.learningclojure.com/2010/09/clojure-swank-server-is-insecure-by.html mentioned that clojure-swank has a dangerous default.
